### PR TITLE
Applying fbalpha2012 commits

### DIFF
--- a/svn-current/trunk/src/burn/devices/eeprom.cpp
+++ b/svn-current/trunk/src/burn/devices/eeprom.cpp
@@ -96,7 +96,7 @@ void EEPROMInit(const eeprom_interface *interface)
 #else
    char slash = '/';
 #endif
-	snprintf (output, sizeof(output), "%s%c%s.nv", g_rom_dir, slash, BurnDrvGetTextA(DRV_NAME));
+	snprintf (output, sizeof(output), "%s%c%s.nv", g_save_dir, slash, BurnDrvGetTextA(DRV_NAME));
 #else
 	snprintf (output, sizeof(output), "config/games/%s.nv", BurnDrvGetTextA(DRV_NAME));
 #endif
@@ -126,7 +126,7 @@ void EEPROMExit()
 #else
    char slash = '/';
 #endif
-	snprintf (output, sizeof(output), "%s%c%s.nv", g_rom_dir, slash, BurnDrvGetTextA(DRV_NAME));
+	snprintf (output, sizeof(output), "%s%c%s.nv", g_save_dir, slash, BurnDrvGetTextA(DRV_NAME));
 #else
 	snprintf (output, sizeof(output), "config/games/%s.nv", BurnDrvGetTextA(DRV_NAME));
 #endif

--- a/svn-current/trunk/src/burn/hiscore.cpp
+++ b/svn-current/trunk/src/burn/hiscore.cpp
@@ -167,7 +167,7 @@ void HiscoreInit()
 #else
    char slash = '/';
 #endif
-	snprintf(szDatFilename, sizeof(szDatFilename), "%s%chiscore.dat", g_rom_dir, slash);
+	snprintf(szDatFilename, sizeof(szDatFilename), "%s%chiscore.dat", g_save_dir, slash);
 #else
 	_stprintf(szDatFilename, _T("%shiscore.dat"), szAppHiscorePath);
 #endif
@@ -222,7 +222,7 @@ void HiscoreInit()
 	
 	TCHAR szFilename[MAX_PATH];
 #ifdef __LIBRETRO__
-	snprintf(szFilename, sizeof(szFilename), "%s%c%s.hi", g_rom_dir, slash, BurnDrvGetText(DRV_NAME));
+	snprintf(szFilename, sizeof(szFilename), "%s%c%s.hi", g_save_dir, slash, BurnDrvGetText(DRV_NAME));
 #else
 	_stprintf(szFilename, _T("%s%s.hi"), szAppHiscorePath, BurnDrvGetText(DRV_NAME));
 #endif
@@ -369,7 +369,7 @@ void HiscoreExit()
 #else
    char slash = '/';
 #endif
-	snprintf(szFilename, sizeof(szFilename), "%s%c%s.hi", g_rom_dir, slash, BurnDrvGetText(DRV_NAME));
+	snprintf(szFilename, sizeof(szFilename), "%s%c%s.hi", g_save_dir, slash, BurnDrvGetText(DRV_NAME));
 #else
 	_stprintf(szFilename, _T("%s%s.hi"), szAppHiscorePath, BurnDrvGetText(DRV_NAME));
 #endif

--- a/svn-current/trunk/src/burner/libretro/burn_libretro_opts.h
+++ b/svn-current/trunk/src/burner/libretro/burn_libretro_opts.h
@@ -15,5 +15,7 @@
 #endif
 
 extern char g_rom_dir[1024];
+extern char g_save_dir[1024];
+extern char g_system_dir[1024];
 
 #endif


### PR DESCRIPTION
Currently, using this core on Android devices and Linux (flatpak), it does not generate the .fs file in the "save" directory, but it can read the files generated by the fbalpha2012 core, which correctly generates the files.

In debug mode, the retroarch log just says "[SRAM]: SRAM will not be saved."

Considering that this core is basically a dismemberment of the core fbalpha2012, I went to check the commits of fbalpha2012 if there were any that dealt with this.

The 5d4f252 commit, of 3/8/2017, corrected the location of the nv, ram and system directory: https://github.com/libretro/fbalpha2012/commit/5d4f2525820008680672df8c7d948d492486c54d

In fbalpha2012_cps3, the changed files had parts of the code pointing to the rom directory instead of save, which was changed in the mentioned commit.

I hope these changes will make the core create the file correctly in the save folder.