### PR TITLE
[WiiU] Aroma CFW Compatibility

### DIFF
--- a/svn-current/trunk/makefile.libretro
+++ b/svn-current/trunk/makefile.libretro
@@ -255,8 +255,8 @@ else ifeq ($(platform), wiiu)
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
    ENDIANNESS_DEFINES =  -DWORDS_BIGENDIAN -DMSB_FIRST
-   PLATFORM_DEFINES := -DGEKKO -DHW_RVL -mwup -mcpu=750 -meabi -mhard-float
-   PLATFORM_DEFINES += -U__INT32_TYPE__ -U __UINT32_TYPE__ -D__INT32_TYPE__=int
+   PLATFORM_DEFINES := -DGEKKO -DHW_RVL -ffunction-sections -fdata-sections 
+   PLATFORM_DEFINES := -D__wiiu__ -D__wut__ -mcpu=750 -meabi -mhard-float
    EXTERNAL_ZLIB = 1
    STATIC_LINKING = 1
 


### PR DESCRIPTION
This update will make the Core compatible with the soon to be released Aroma Retroarch port.
This should also be Tiramisu safe too so should be good to merge :)